### PR TITLE
KillJob

### DIFF
--- a/client.go
+++ b/client.go
@@ -363,6 +363,14 @@ func (c *Client) DeleteDeadJob(diedAt int64, jobID string) error {
 	return nil
 }
 
+// KillJob flags a job to be stopped.
+func (c *Client) KillJob(jobID string) error {
+	conn := c.pool.Get()
+	defer conn.Close()
+
+	return conn.Send("SETEX", redisKeyKilledJob(c.namespace, jobID), 60*60, 1)
+}
+
 // RetryDeadJob retries a dead job. The job will be re-queued on the normal work queue for eventual processing by a worker.
 func (c *Client) RetryDeadJob(diedAt int64, jobID string) error {
 	// Get queues for job names

--- a/job.go
+++ b/job.go
@@ -16,6 +16,7 @@ type Job struct {
 	Args       map[string]interface{} `json:"args"`
 	Unique     bool                   `json:"unique,omitempty"`
 	UniqueKey  string                 `json:"unique_key,omitempty"`
+	PoolID     string                 `json:"pool_id"`
 
 	// Inputs when retrying
 	Fails    int64  `json:"fails,omitempty"` // number of times this job has failed

--- a/redis.go
+++ b/redis.go
@@ -90,6 +90,10 @@ func redisKeyUniqueJob(namespace, jobName string, args map[string]interface{}) (
 	return buf.String(), nil
 }
 
+func redisKeyKilledJob(namespace, jobID string) string {
+	return redisNamespacePrefix(namespace) + jobID + ":killed"
+}
+
 func redisKeyLastPeriodicEnqueue(namespace string) string {
 	return redisNamespacePrefix(namespace) + "last_periodic_enqueue"
 }

--- a/worker.go
+++ b/worker.go
@@ -208,6 +208,7 @@ func (w *worker) processJob(job *Job) {
 		w.observeStarted(job.Name, job.ID, job.Args)
 		job.observer = w.observer // for Checkin
 		job.aliveChecker = w.alive
+		job.PoolID = w.poolID
 		_, runErr = runJob(job, w.contextType, w.middleware, jt)
 		w.observeDone(job.Name, job.ID, runErr)
 	}

--- a/worker.go
+++ b/worker.go
@@ -271,19 +271,21 @@ func (w *worker) alive(job *Job) bool {
 
 	key := redisKeyKilledJob(w.namespace, job.ID)
 
-	killed, err := redis.Int(conn.Do("GET", key))
-	if err != nil && err != redis.ErrNil {
-		logError("worker.alive.get", err)
+	_, err := redis.Int(conn.Do("GET", key))
+	if err != nil {
+		if err != redis.ErrNil {
+			logError("worker.jobalive.get", err)
+		}
+
 		return true
 	}
 
 	_, err = conn.Do("DEL", key)
 	if err != nil {
-		logError("worker.alive.del", err)
-		return true
+		logError("worker.jobalive.del", err)
 	}
 
-	return killed != 1
+	return false
 }
 
 func (w *worker) removeJobFromInProgress(job *Job, fate terminateOp) {


### PR DESCRIPTION
Add support to stop a job during its execution

```golang
func (c *Context) SendEmail(job *work.Job) error {
    for {
	if !job.Alive() {
	    break
	}

	// do task
    }

    return nil
}
```

`client.KillJob` adds a redis key {namespace}:{jobid}:killed
`job.Alive` queries the key, if found `Alive` returns false and the
key is deleted