### PR TITLE
Don't retry if job is killed

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -311,7 +311,7 @@ func terminateAndDead(w *worker, job *Job) terminateOp {
 func (w *worker) jobFate(jt *jobType, job *Job) terminateOp {
 	if jt != nil {
 		failsRemaining := int64(jt.MaxFails) - job.Fails
-		if failsRemaining > 0 {
+		if failsRemaining > 0 && !job.Killed() {
 			return terminateAndRetry(w, jt, job)
 		}
 		if jt.SkipDead {


### PR DESCRIPTION
When jobs are terminated in desk admin they are still being added to the retry queue. I think this should fix it. A job is only killed when discarded right?